### PR TITLE
Fixing incorrect return type for getActivityTask

### DIFF
--- a/src/lib/actions/api/__tests__/get-activity-task.test.js
+++ b/src/lib/actions/api/__tests__/get-activity-task.test.js
@@ -12,7 +12,7 @@ describe('Get activity task', () => {
       };
       const { response } = getActivityTask(params, activities);
       expect(response).toMatchObject({
-        input: activity.tasks[0].input,
+        input: JSON.stringify(activity.tasks[0].input),
         taskToken: activity.tasks[0].taskToken,
       });
     } catch (e) {

--- a/src/lib/actions/api/get-activity-task.js
+++ b/src/lib/actions/api/get-activity-task.js
@@ -27,7 +27,7 @@ function getActivityTask(params, activities) {
 
   const scheduledTask = match.tasks.find(t => t.status === status.activity.SCHEDULED);
   const response = scheduledTask ? {
-    input: scheduledTask.input,
+    input: JSON.stringify(scheduledTask.input),
     taskToken: scheduledTask.taskToken,
   } : null;
   return {


### PR DESCRIPTION
While testing this project against the AWS Java SDK, I discovered that the input parameter returned from the getActivityTask call needs to be a string type rather than an object type.