### PR TITLE
Undefined is a valid return value for Lambda function's

### DIFF
--- a/src/lib/tools/__tests__/path.test.js
+++ b/src/lib/tools/__tests__/path.test.js
@@ -33,4 +33,9 @@ describe('Path', () => {
       },
     });
   });
+
+  it('should apply undefined objects', () => {
+    expect(applyInputPath(undefined)).toMatchObject({});
+    expect(applyOutputPath(undefined)).toMatchObject({});
+  });
 });

--- a/src/lib/tools/path.js
+++ b/src/lib/tools/path.js
@@ -12,7 +12,10 @@ function createNestedObject(object, keys, defaultValue) {
 }
 
 function applyJsonPath(object, path = '$') {
-  return jp.value(object, path) || {};
+  if (object) {
+    return jp.value(object, path) || {};
+  }
+  return {};
 }
 
 function applyInputPath(object, path) {

--- a/src/lib/tools/path.js
+++ b/src/lib/tools/path.js
@@ -12,7 +12,7 @@ function createNestedObject(object, keys, defaultValue) {
 }
 
 function applyJsonPath(object, path = '$') {
-  if (typeof object === 'object' && object !=== null) {
+  if (typeof object === 'object' && object !== null) {
     return jp.value(object, path) || {};
   }
   return {};

--- a/src/lib/tools/path.js
+++ b/src/lib/tools/path.js
@@ -12,7 +12,7 @@ function createNestedObject(object, keys, defaultValue) {
 }
 
 function applyJsonPath(object, path = '$') {
-  if (object) {
+  if (typeof object === 'object' && object !=== null) {
     return jp.value(object, path) || {};
   }
   return {};


### PR DESCRIPTION
When an undefinedvalue is returned from a Lambda, the step function throws an exception and enters the Catch state.  The assertion error is caused by jsonpath.value(obj /\*undefined\*/, path, value) throwing an assertion error when obj is undefined: ["obj needs to be an object"](https://github.com/dchester/jsonpath/blob/9713c6f94198df510d9ebb6b2a73fce3762e6601/lib/index.js#L53)

AssertionError [ERR_ASSERTION]: obj needs to be an object
    at JSONPath.value (node_modules/jsonpath/lib/index.js:53:10)
    at applyJsonPath (src/lib/tools/path.js:15:13)
    at applyOutputPath (src/lib/tools/path.js:23:10)
    at Task.get output [as output] (src/lib/states/task.js:212:12)
    at Task.execute (src/lib/states/task.js:156:26)
    at <anonymous>
    at process._tickDomainCallback (internal/process/next_tick.js:228:7)
