### PR TITLE
Fix ECS failures check and missing arg

### DIFF
--- a/src/lib/states/__tests__/task.test.js
+++ b/src/lib/states/__tests__/task.test.js
@@ -217,6 +217,7 @@ describe('Test mocked ECS task, asynchronous', () => {
           lastStatus: 'PENDING',
         },
       ],
+      failures: [],
     };
 
     // mock successful execution

--- a/src/lib/states/__tests__/task.test.js
+++ b/src/lib/states/__tests__/task.test.js
@@ -110,8 +110,20 @@ describe('Test mocked ECS task, synchronous', () => {
     };
 
     // mock successfull execution
-    AWS.mock('ECS', 'runTask', Promise.resolve(runTaskResult));
-    AWS.mock('ECS', 'describeTasks', Promise.resolve(describeTasksResult));
+    AWS.mock('ECS', 'runTask', (params) => {
+      expect(params.cluster).toEqual(state.Parameters.Cluster);
+      expect(params.taskDefinition).toEqual(state.Parameters.TaskDefinition);
+
+      return Promise.resolve(runTaskResult);
+    });
+
+    AWS.mock('ECS', 'describeTasks', (params) => {
+      expect(params.cluster).toEqual(state.Parameters.Cluster);
+      expect(params.tasks).toEqual([runTaskResult.tasks[0].taskArn]);
+
+      return Promise.resolve(describeTasksResult);
+    });
+
     const input = { comment: 'input' };
     const res = await task.execute(input);
     expect(res.output).toEqual(describeTasksResult);
@@ -148,11 +160,19 @@ describe('Test mocked ECS task, synchronous', () => {
     };
 
     // mock successfull execution
-    AWS.mock('ECS', 'runTask', Promise.resolve(runTaskResult));
+    AWS.mock('ECS', 'runTask', (params) => {
+      expect(params.cluster).toEqual(state.Parameters.Cluster);
+      expect(params.taskDefinition).toEqual(state.Parameters.TaskDefinition);
+
+      return Promise.resolve(runTaskResult);
+    });
 
     let describeTasksCalls = 0;
 
-    AWS.mock('ECS', 'describeTasks', () => {
+    AWS.mock('ECS', 'describeTasks', (params) => {
+      expect(params.cluster).toEqual(state.Parameters.Cluster);
+      expect(params.tasks).toEqual([runTaskResult.tasks[0].taskArn]);
+
       describeTasksCalls += 1;
       describeTasksResult.tasks[0].lastStatus = describeTasksCalls < 3 ? 'PENDING' : 'STOPPED';
       return Promise.resolve(describeTasksResult);
@@ -221,7 +241,12 @@ describe('Test mocked ECS task, asynchronous', () => {
     };
 
     // mock successful execution
-    AWS.mock('ECS', 'runTask', Promise.resolve(runTaskResult));
+    AWS.mock('ECS', 'runTask', (params) => {
+      expect(params.cluster).toEqual(state.Parameters.Cluster);
+      expect(params.taskDefinition).toEqual(state.Parameters.TaskDefinition);
+
+      return Promise.resolve(runTaskResult);
+    });
 
     const input = { comment: 'input' };
     const res = await task.execute(input);

--- a/src/lib/states/task-ecs.js
+++ b/src/lib/states/task-ecs.js
@@ -36,7 +36,7 @@ class TaskEcs extends Task {
 
     const runTaskResult = await ecs.runTask(params).promise();
 
-    if (runTaskResult.failures) {
+    if (runTaskResult.failures && runTaskResult.failures.length > 0) {
       throw new Error(`There were failures running the ECS Task for state ${this.name}: ${JSON.stringify(runTaskResult.failures)}`);
     }
 

--- a/src/lib/states/task-ecs.js
+++ b/src/lib/states/task-ecs.js
@@ -44,7 +44,7 @@ class TaskEcs extends Task {
 
     if (this.useSync) {
       const task = TaskEcs.getTaskFromEcsTaskResult(runTaskResult);
-      return this.waitForEcsTaskToFinish(ecs, task.taskArn);
+      return this.waitForEcsTaskToFinish(ecs, parameters, task.taskArn);
     }
 
     return runTaskResult;


### PR DESCRIPTION
Fix two bugs:

1. It turns out that the ECS API returns an empty `failures` array on successful executions, and in JS, an empty array is "truthy", so even though the ECS Task execution succeeds, stepfunctions-local always reports an error.

1. I simply missed passing an argument to the `waitForEcsTaskToFinish` method. This would've been caught by a proper type system 😕 

I've updated automated tests to fail for both cases and then fixed the bug.