### PR TITLE
Make applyJsonPath pass input value if not an object

### DIFF
--- a/src/lib/tools/__tests__/path.test.js
+++ b/src/lib/tools/__tests__/path.test.js
@@ -34,8 +34,11 @@ describe('Path', () => {
     });
   });
 
-  it('should apply undefined objects', () => {
-    expect(applyInputPath(undefined)).toMatchObject({});
-    expect(applyOutputPath(undefined)).toMatchObject({});
+  it('should apply pass through non-objects untouched', () => {
+    expect(applyInputPath(undefined)).toBe(undefined);
+    expect(applyInputPath(1)).toBe(1);
+    expect(applyInputPath('foobar')).toBe('foobar');
+    expect(applyInputPath([1,2,3])).toBe([1,2,3]);
+    expect(applyInputPath([])).toBe([]);
   });
 });

--- a/src/lib/tools/__tests__/path.test.js
+++ b/src/lib/tools/__tests__/path.test.js
@@ -35,10 +35,10 @@ describe('Path', () => {
   });
 
   it('should apply pass through non-objects untouched', () => {
-    expect(applyInputPath(undefined)).toBe(undefined);
-    expect(applyInputPath(1)).toBe(1);
-    expect(applyInputPath('foobar')).toBe('foobar');
-    expect(applyInputPath([1,2,3])).toBe([1,2,3]);
-    expect(applyInputPath([])).toBe([]);
+    expect(applyInputPath(undefined)).toEqual(undefined);
+    expect(applyInputPath(1)).toEqual(1);
+    expect(applyInputPath('foobar')).toEqual('foobar');
+    expect(applyInputPath([1,2,3])).toEqual([1,2,3]);
+    expect(applyInputPath([])).toEqual([]);
   });
 });

--- a/src/lib/tools/path.js
+++ b/src/lib/tools/path.js
@@ -15,7 +15,7 @@ function applyJsonPath(object, path = '$') {
   if (typeof object === 'object' && object !== null) {
     return jp.value(object, path) || {};
   }
-  return {};
+  return object;
 }
 
 function applyInputPath(object, path) {


### PR DESCRIPTION
This is a resolution to #48 

Instead of rejecting a non-object value, I updated `applyJsonPath` to just pass it through unmodified.