### PR TITLE
Fix parallel state not correctly assigning branch output to ResultPath

### DIFF
--- a/src/lib/states/__tests__/parallel.test.js
+++ b/src/lib/states/__tests__/parallel.test.js
@@ -90,6 +90,49 @@ describe('Parallel', () => {
     expect(nextState).toEqual('Final State');
   });
 
+  it('should send branch output to ResultPath', async () => {
+    const state = {
+      Type: 'Parallel',
+      Next: 'Final State',
+      ResultPath: '$.result',
+      Branches: [
+        {
+          StartAt: 'Pass',
+          States: {
+            Pass: {
+              Type: 'Pass',
+              InputPath: "$.first",
+              End: true,
+            },
+          },
+        },
+        {
+          StartAt: 'Pass',
+          States: {
+            Pass: {
+              Type: 'Pass',
+              InputPath: "$.second",
+              End: true,
+            },
+          },
+        },
+      ],
+    };
+    const input = {
+      first: 1,
+      second: 2
+    };
+
+    const expectedOutput = {
+      first: 1,
+      second: 2,
+      result: [1, 2]
+    };
+    const parallelInstance = new Parallel(state, execution, 'ParallelState', {});
+    const { output } = await parallelInstance.execute(input);
+    expect(output).toEqual(expectedOutput);
+  });
+
   it('should fail and retry', async () => {
     AWS.mock('Lambda', 'invoke', () => {
       throw new Error('I am a failing Lambda...');

--- a/src/lib/states/__tests__/parallel.test.js
+++ b/src/lib/states/__tests__/parallel.test.js
@@ -101,7 +101,7 @@ describe('Parallel', () => {
           States: {
             Pass: {
               Type: 'Pass',
-              InputPath: "$.first",
+              InputPath: '$.first',
               End: true,
             },
           },
@@ -111,7 +111,7 @@ describe('Parallel', () => {
           States: {
             Pass: {
               Type: 'Pass',
-              InputPath: "$.second",
+              InputPath: '$.second',
               End: true,
             },
           },
@@ -120,13 +120,13 @@ describe('Parallel', () => {
     };
     const input = {
       first: 1,
-      second: 2
+      second: 2,
     };
 
     const expectedOutput = {
       first: 1,
       second: 2,
-      result: [1, 2]
+      result: [1, 2],
     };
     const parallelInstance = new Parallel(state, execution, 'ParallelState', {});
     const { output } = await parallelInstance.execute(input);

--- a/src/lib/states/parallel.js
+++ b/src/lib/states/parallel.js
@@ -22,8 +22,7 @@ class Parallel extends State {
             const branch = new StateMachine(branchObj, this.execution, this.config);
 
             const result = await branch.execute(this.input);
-            const output = applyResultPath(this.input, this.state.ResultPath, result.output);
-            return applyOutputPath(output, this.state.OutputPath);
+            return result.output;
           }));
           addHistoryEvent(this.execution, 'PARALLEL_STATE_SUCCEEDED');
           addHistoryEvent(this.execution, 'PARALLEL_STATE_EXITED');
@@ -37,7 +36,8 @@ class Parallel extends State {
           }
         }
       } while (!branchesOutputs);
-      this.branchesOutputs = branchesOutputs;
+      const output = applyResultPath(this.input, this.state.ResultPath, branchesOutputs);
+      this.branchesOutputs = applyOutputPath(output, this.state.OutputPath);
     } catch (e) {
       addHistoryEvent(this.execution, 'PARALLEL_STATE_FAILED', {
         cause: e.name,


### PR DESCRIPTION
This PR fixes an issue with where the ResultPath on parallel states doesn't work properly.

Steps to reproduce (included as a test):

1. Create this state machine:
```
{
  "Comment": "Test Step Function",
  "StartAt": "Parallel",
  "States": {
    "Parallel": {
      "Type": "Parallel",
      "ResultPath": "$.result",
      "End": true,
      "Branches": [
        {
          "StartAt": "First",
          "States": {
            "First": { "Type": "Pass", "InputPath": "$.first", "End": true }
          }
        },
        {
          "StartAt": "Second",
          "States": {
            "Second": { "Type": "Pass", "InputPath": "$.second", "End": true }
          }
        }
      ]
    }
  }
}

```

2. Run this state machine with this input: `{"first": 1, "second": 2}`

Expected result: `{"first": 1, "result": [1, 2], "second": 2}`

Actual result: `[{"first": 1, "result": 1, "second": 2}, {"first": 1, "result": 2, "second": 2}]`


[API documentation](https://docs.aws.amazon.com/step-functions/latest/dg/amazon-states-language-parallel-state.html)

> A Parallel state provides each branch with a copy of its own input data (subject to modification by the InputPath field). It generates output that is an array with one element for each branch, containing the output from that branch. There is no requirement that all elements be of the same type. The output array can be inserted into the input data (and the whole sent as the Parallel state's output) by using a ResultPath field in the usual way.

> ResultPath (Optional) Specifies where (in the input) to place the output of the branches. The input is then filtered as specified by the OutputPath field (if present) before being used as the state's output.